### PR TITLE
WIP recurring invite

### DIFF
--- a/providers/googlecalendar/examples/event.tf
+++ b/providers/googlecalendar/examples/event.tf
@@ -3,8 +3,12 @@ resource "googlecalendar_event" "peddy_kyle" {
   description = "See summary"
   location    = "Fort Asshole"
 
-  start = "2019-07-07T13:00:00-05:00"
-  end   = "2019-07-07T14:00:00-05:00"
+  start = "2019-07-18T13:00:00-05:00"
+  end   = "2019-07-18T14:00:00-05:00"
+
+  recurrence = [
+    "RRULE:FREQ=WEEKLY;BYDAY=TH",
+  ]
 
   attendee {
     email = "pedrampejman2010@gmail.com"
@@ -12,4 +16,6 @@ resource "googlecalendar_event" "peddy_kyle" {
   attendee {
     email = "kylevonbredow@gmail.com"
   }
+
+  guests_can_modify = true
 }


### PR DESCRIPTION
Currently a work in progress for recurring invites.

According to the golang library [docs](https://godoc.org/google.golang.org/api/calendar/v3#EventDateTime), Google Calendar requires the TimeZone field in the `start` and `end` objects for API requests with the `recurrence ` field set.

Currently I'm having trouble parsing the time specified according to RFC3339 and extracting the timezone string (e.g. "America/New_York") using the standard go library.